### PR TITLE
Fix number font rendering issue

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,7 +42,7 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground lining-nums tabular-nums;
     background: linear-gradient(
       to bottom,
       transparent,
@@ -76,6 +76,7 @@
     background: white !important;
     color: black !important;
     font-family: 'Inter', -apple-system, sans-serif !important;
+    font-variant-numeric: lining-nums tabular-nums !important;
   }
 
   /* Format the main content for print */


### PR DESCRIPTION
Apply `lining-nums` and `tabular-nums` font variants to correctly display numbers instead of incorrect glyphs.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce3b8937-8769-4378-a06f-157e0975e7b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce3b8937-8769-4378-a06f-157e0975e7b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

